### PR TITLE
Update least_cost_path_provider.py

### DIFF
--- a/least_cost_path_provider.py
+++ b/least_cost_path_provider.py
@@ -38,9 +38,7 @@ class LeastCostPathProvider(QgsProcessingProvider):
 
     def __init__(self):
         QgsProcessingProvider.__init__(self)
-
-        # Load algorithms
-        self.alglist = [LeastCostPathAlgorithm()]
+    
 
     def unload(self):
         """
@@ -53,8 +51,8 @@ class LeastCostPathProvider(QgsProcessingProvider):
         """
         Loads all algorithms belonging to this provider.
         """
-        for alg in self.alglist:
-            self.addAlgorithm( alg )
+        
+        self.addAlgorithm(LeastCostPathAlgorithm())
 
     def id(self):
         """


### PR DESCRIPTION
Fixes "RuntimeError: wrapped C/C++ object of type LeastCostPathAlgorithm has been deleted".
based on [this](https://github.com/jdugge/BufferByPercentage/pull/14/commits/04269ff6b25433253259294eb480a10e4b353403)

***This is my first pull request, feel free to ignore or tell me I'm wrong I have no idea what I'm doing***